### PR TITLE
Clarify that blupmania is licensed under GPLv3+

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,18 +1,71 @@
-# Copying
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Blupi Mania
+Upstream-Contact: Mathieu Schroeter <mathieu@schroetersa.ch>
+Source: https://github.com/blupi-games/blupimania/
 
-| Years     | People                                                           |
-| --------- | ---------------------------------------------------------------- |
-|           | **Developers**                                                   |
-| 1994-1996 | Daniel Roux                                                      |
-| 1995-1996 | Michaël Walz (DOS port)                                          |
-| 2023      | Mathieu Schroeter                                                |
-|           |                                                                  |
-|           | **Translators**                                                  |
-| 1995-1996 | Michael Walz, David Besuchet                                     |
-|           |                                                                  |
-|           | **Levels**                                                       |
-| 1994-1995 | Daniel Roux, Denis Dumoulin, Anny-Sylvie Crisinel,               |
-|           | Jean-François Crisinel                                           |
-|           |                                                                  |
-|           | **Testers**                                                      |
-| 2023      | Nathan Schroeter, Aurore Schroeter                               |
+Files: *
+Copyright: 2023, Mathieu Schroeter
+           1994-1996, Daniel Roux & EPSITEC SA
+License: GPL-3+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 3 dated June, 2007, or (at
+ your option) any later version.
+ .
+ The complete text of version 3 of the GNU General Public License can
+ be found 'LICENSE'.
+
+Files: src/argtable3/argtable3.*
+Copyright: 1998-2001, 2003-2011, 2013 Stewart Heitmann
+License: BSD-3-Clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ 3. Neither the name(s) of the above-listed copyright holder(s) nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Files: src/sdl/SDL3_IMG*
+Copyright: 1997-2023 Sam Lantinga <slouken@libsdl.org>
+License: Zlib
+ The zlib License
+ .
+ This software is provided 'as-is', without any express or implied
+ warranty. In no event will the authors be held liable for any damages
+ arising from the use of this software.
+ .
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ .
+   1. The origin of this software must not be misrepresented; you must
+      not claim that you wrote the original software. If you use this
+      software in a product, an acknowledgment in the product
+      documentation would be appreciated but is not required.
+ .
+   2. Altered source versions must be plainly marked as such, and must
+      not be misrepresented as being the original software.
+ .
+   3. This notice may not be removed or altered from any source
+      distribution.
+

--- a/CREDITS
+++ b/CREDITS
@@ -1,0 +1,18 @@
+# Copying
+
+| Years     | People                                                           |
+| --------- | ---------------------------------------------------------------- |
+|           | **Developers**                                                   |
+| 1994-1996 | Daniel Roux                                                      |
+| 1995-1996 | Michaël Walz (DOS port)                                          |
+| 2023      | Mathieu Schroeter                                                |
+|           |                                                                  |
+|           | **Translators**                                                  |
+| 1995-1996 | Michael Walz, David Besuchet                                     |
+|           |                                                                  |
+|           | **Levels**                                                       |
+| 1994-1995 | Daniel Roux, Denis Dumoulin, Anny-Sylvie Crisinel,               |
+|           | Jean-François Crisinel                                           |
+|           |                                                                  |
+|           | **Testers**                                                      |
+| 2023      | Nathan Schroeter, Aurore Schroeter                               |

--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,7 @@ This game is linked on some static libraries:
   zlib (own license)
 
 
-Blupimania is licensed under GPLv3, see LICENSE.all/copyright for details.
+Blupimania is licensed under GPLv3+, see LICENSE.all/copyright for details.
 
 
                     GNU GENERAL PUBLIC LICENSE

--- a/LICENSE.all
+++ b/LICENSE.all
@@ -15,7 +15,7 @@ List of all licenses, concerns Blupimania and dependencies
  * zlib -- https://zlib.net/
 
 ######################################################################
-# Blupimania - LICENSE
+# Blupimania is licensed under GPLv3+
 ######################################################################
 
                     GNU GENERAL PUBLIC LICENSE


### PR DESCRIPTION
… Also list the code copies from argtable3 and SDL3.

This would address #11 , I hope.